### PR TITLE
Specify --arch/--platform when compiling libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,7 @@ set(LIBRARIES "")
 macro(generate_library LIB_NAME ARCH PLATFORM RUNTIME)
 	add_custom_command(OUTPUT ${INTERMEDIATE}/${LIB_NAME}.lib
 		DEPENDS scc_bootstrap
-		COMMAND ${CMAKE_COMMAND} -E env ASAN_OPTIONS=detect_leaks=0 $<TARGET_FILE:scc_bootstrap> ${${RUNTIME}} -f lib -o ${INTERMEDIATE}/${LIB_NAME}.lib
+		COMMAND ${CMAKE_COMMAND} -E env ASAN_OPTIONS=detect_leaks=0 $<TARGET_FILE:scc_bootstrap> ${${RUNTIME}} --arch ${ARCH} --platform ${PLATFORM} -f lib -o ${INTERMEDIATE}/${LIB_NAME}.lib
 		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 		COMMENT "Generating runtime library ${LIB_NAME}")
 


### PR DESCRIPTION
These arguments matter since the compiler can potentially emit different IL depending on arch. For example, if the arch supports strlen intrinsic then ILOP_STRLEN instruction is used, otherwise a call to __strlen is generated instead. Trying to use the ILOP_STRLEN instruction on an arch that doesn't actually support it will spit out an error when trying to actually generate the machine code. A simple test that shows this exact issue is trying to compile a simple printf "Hello world" program for aarch64.

Based on git history, seems these arguments were passed back when Makefile was being used, but was removed unintentionally(?) when converting to CMake.

Should close https://github.com/Vector35/binaryninja-api/issues/5340